### PR TITLE
Convert to Python 3 and command line validation

### DIFF
--- a/get_schema.py
+++ b/get_schema.py
@@ -170,9 +170,14 @@ def reduce_indexes(table, index_list, errors):
 # reduce_indexes.
 
 def get_schema(schema_version, errors):
-    f = open('pickles/%s' % schema_version, 'rb')
-    (sv, schema) = pickle.load(f)
-    f.close()
+    f = None
+    schema = {}
+    try:
+        f = open('pickles/%s' % schema_version, 'rb')
+        (sv, schema) = pickle.load(f)
+        f.close()
+    except Exception as e:
+        errors.append("%s: %s" % (type(e).__name__, str(e)))
     tables = list(schema.keys())
     for table in tables:
         (columns, indexes) = schema[table]

--- a/get_schema.py
+++ b/get_schema.py
@@ -77,7 +77,7 @@ def reduce_columns(table, description, errors):
             default = '0'
         if (sqltype == 'datetime' and default == ''):
             default = '0000-00-00 00:00:00'
-        if (sqltype[:7] == 'decimal' and (default == '' or float(default) == 0.0)):
+        if (sqltype[:7] == 'decimal' and (default == '' or default == None or float(default) == 0.0)):
             default = "0.0"
         if default == '':
             default = "''"

--- a/get_schema.py
+++ b/get_schema.py
@@ -176,6 +176,8 @@ def get_schema(schema_version, errors):
         f = open('pickles/%s' % schema_version, 'rb')
         (sv, schema) = pickle.load(f)
         f.close()
+    except FileNotFoundError:
+        errors.append("Unable to locate schema data file for version %s" % (schema_version))
     except Exception as e:
         errors.append("%s: %s" % (type(e).__name__, str(e)))
     tables = list(schema.keys())

--- a/get_schema.py
+++ b/get_schema.py
@@ -23,8 +23,6 @@ import schema_remarks
 import string
 import re
 
-error = 'getting a schema'
-
 # 3. Obtaining a schema, and reducing it to a normal form.
 
 # This is a map from type names (as returned by a 'describe'

--- a/index.cgi
+++ b/index.cgi
@@ -1,4 +1,4 @@
-#!/usr/local/bin/python
+#!/usr/bin/python3
 # 
 #                              Ravenbrook
 #                     <http://www.ravenbrook.com/>

--- a/index.py
+++ b/index.py
@@ -233,15 +233,15 @@ class webpage:
         except BzSchemaProcessingException as e:
             self.status = 500
             self.status_message = "Schema processing error"
-            error_message = e.message
+            error_message = str(e)
             self.title = self.status_message
             self.h1 = self.title
             self.body = ['<p>%s</p>' % error_message]
-        except:
-            (error_type, error_value, _) = sys.exc_info()
+        except Exception as e:
+            error_type = type(e).__name__
+            error_value = str(e)
             self.status = 500
             error_message = '%s: %s' % (error_type, error_value)
-            raise
             self.status_message = 'Python error'
             self.title = self.status_message
             self.h1 = self.title

--- a/make_schema_doc.py
+++ b/make_schema_doc.py
@@ -32,7 +32,7 @@ class BzSchemaProcessingException(Exception):
         super().__init__(message)
         self.message = message
     def __str__(self):
-        return self.message
+        return '\n' + self.message
 
 errors = []
 

--- a/make_schema_doc.py
+++ b/make_schema_doc.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python3
 #             Perforce Defect Tracking Integration Project
 #              <http://www.ravenbrook.com/project/p4dti/>
 #
@@ -20,6 +21,7 @@ import copy
 import re
 import types
 import time
+import sys
 
 import schema_remarks
 import get_schema
@@ -757,6 +759,14 @@ def write_file(first, last, filename):
 def make_body(first, last):
     (header, body, footer) = make_tables(first, last)
     return body
+
+if __name__ == "__main__":
+    try:
+        (first, last, filename) = sys.argv[1:]
+    except ValueError:
+        print("Please pass the starting and ending schema versions and a filename to output to.")
+        sys.exit()
+    write_file(first, last, filename)
 
 # A. REFERENCES
 #

--- a/make_schema_doc.py
+++ b/make_schema_doc.py
@@ -341,7 +341,6 @@ def output_schema(schema, remarks, colours, bugzilla_versions):
         if not isinstance(thisremarks, list): thisremarks = [thisremarks]
         remark = str.join(' ',
                   [process(r,bugzilla_versions,dict) for r in thisremarks])
-                  #list(map(lambda r,bv=bugzilla_versions,d=dict: process(r,bv,d),remarks[table])))
         tables_table_rows.append(('<th%s><a href="#table-%s">%s</a></th>\n\n' % (colour, table, table)) +
                                  ('    <td%s>%s</td>\n\n' % (colour, remark)))
         quick_tables_table_rows.append('<th%s><a href="#table-%s">%s</a></th>\n\n' % (colour, table, table))

--- a/make_schema_doc.py
+++ b/make_schema_doc.py
@@ -20,12 +20,9 @@ import copy
 import re
 import types
 import time
-import sys
 
 import schema_remarks
 import get_schema
-
-from pprint import pprint
 
 error = 'Schema processing error'
 

--- a/make_schema_doc.py
+++ b/make_schema_doc.py
@@ -16,7 +16,6 @@
 #
 # This document is not confidential.
 
-import string
 import copy
 import re
 import types
@@ -474,10 +473,10 @@ def stringify_type(pl):
             if items == []:
                 # first enum
                 newpl.append(p)
-                items = list(map(string.strip, string.split(enum_re.match(p[1]).groups()[0], ",")))
+                items = list(map(str.strip, str.split(enum_re.match(p[1]).groups()[0], ",")))
             else:
                 # enum following an enum
-                new_items = list(map(string.strip, string.split(enum_re.match(p[1]).groups()[0], ",")))
+                new_items = list(map(str.strip, str.split(enum_re.match(p[1]).groups()[0], ",")))
                 add = []
                 delete = []
                 for i in items:

--- a/make_schema_doc.py
+++ b/make_schema_doc.py
@@ -35,39 +35,12 @@ class BzSchemaProcessingException(Exception):
 
 errors = []
 
-# 4. Handling multiple Bugzilla versions.
-#
-# version_compare is a comparison function for Bugzilla version names.
-# e.g. 2.17.1 > 2.16.5 > 2.16 > 2.16rc1 > 2.14.5.
-#
-# It works by breaking the version name into a list of items (major,
-# minor, optional separator, optional release), transforming each item
-# into an integer, and comparing the list of items.
-#
-# 2.17.1  -> 2,17,2,1
-# 2.16.5  -> 2,16,2,5
-# 2.16    -> 2,16,1,1
-# 2.16rc1 -> 2,16,0,1
-
-version_re = re.compile('(\\d+)\\.(\\d+)(rc|\\.)?(\\d+)?')
-
-def version_item_transform(x):
-    if x is None:
-        return 1
-    elif x == 'rc':
-        return 0
-    elif x == '.':
-        return 2
-    else:
-        return int(x)
-
-def cmp(a, b):
-    return (a > b) - (a < b) 
-
 def version_compare(v1,v2):
-    v1m = list(map(version_item_transform, version_re.match(v1).groups()))
-    v2m = list(map(version_item_transform, version_re.match(v2).groups()))
-    return cmp(v1m, v2m)
+    # we already have the order defined in a table, let's use it
+    # this also lets us make 5.1 be > 5.2 (which is actually true)
+    v1idx = schema_remarks.version_order.index(v1)
+    v2idx = schema_remarks.version_order.index(v2)
+    return (v1idx > v2idx) - (v1idx < v2idx)
 
 vd_cache = {}
 

--- a/pickle_schema.py
+++ b/pickle_schema.py
@@ -16,7 +16,7 @@
 # This document is not confidential.
 
 import MySQLdb
-import cPickle
+import pickle
 
 def fetchall(cursor):
     rows = cursor.fetchall()
@@ -28,11 +28,11 @@ def fetchall(cursor):
 def select_rows(cursor, select):
     rows = cursor.execute(select)
     if cursor.description == None :
-        raise error, ("Trying to fetch rows from non-select '%s'"
+        raise error("Trying to fetch rows from non-select '%s'"
                       % select)
     values = fetchall(cursor)
     if values == None :
-        raise error, ("Select '%s' returned unfetchable rows."
+        raise error("Select '%s' returned unfetchable rows."
                       % select)
     return values
 
@@ -49,7 +49,7 @@ def fetch_rows_as_list_of_dictionaries(cursor, select):
     for value in values:
         result={}
         if len(keys) != len(value) :
-            raise error, ("Select '%s' returns %d keys but %d columns."
+            raise error("Select '%s' returns %d keys but %d columns."
                           % (select, len(keys), len(value)))
         for j in range(len(keys)):
             result[keys[j]] = value[j]
@@ -59,7 +59,7 @@ def fetch_rows_as_list_of_dictionaries(cursor, select):
 def pickle_schema(schema_version, db_name):
     db = MySQLdb.connect(db=db_name, user='bugs')
     cursor = db.cursor()
-    tables = map(lambda x:x[0],select_rows(cursor, 'show tables'))
+    tables = [x[0] for x in select_rows(cursor, 'show tables')]
     schema = {}
     for table in tables:
         columns = fetch_rows_as_list_of_dictionaries(cursor,
@@ -68,8 +68,8 @@ def pickle_schema(schema_version, db_name):
                                                      'show index from %s' % table)
         schema[table] = (columns, indexes)
     db.close()
-    f = open('pickles/%s' % schema_version, 'w')
-    cPickle.dump((schema_version, schema), f)
+    f = open('pickles/%s' % schema_version, 'wb')
+    pickle.dump((schema_version, schema), f)
     f.close()
     
 # A. REFERENCES

--- a/pickle_schema.py
+++ b/pickle_schema.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python3
 #             Perforce Defect Tracking Integration Project
 #              <http://www.ravenbrook.com/project/p4dti/>
 #
@@ -17,6 +18,8 @@
 
 import MySQLdb
 import pickle
+import sys
+import os
 
 class BzSchemaPickleException(Exception):
     def __init__(self, message):
@@ -64,7 +67,8 @@ def fetch_rows_as_list_of_dictionaries(cursor, select):
     return results
 
 def pickle_schema(schema_version, db_name):
-    db = MySQLdb.connect(db=db_name, user='bugs')
+    default_file = os.path.expanduser('~/.my.cnf')
+    db = MySQLdb.connect(database=db_name, read_default_file=default_file)
     cursor = db.cursor()
     tables = [x[0] for x in select_rows(cursor, 'show tables')]
     schema = {}
@@ -79,6 +83,14 @@ def pickle_schema(schema_version, db_name):
     pickle.dump((schema_version, schema), f)
     f.close()
     
+if __name__ == "__main__":
+    try:
+        (schema_version, db_name) = sys.argv[1:]
+    except ValueError:
+        print("Please pass the schema version and the database name.")
+        sys.exit()
+    pickle_schema(schema_version, db_name)
+
 # A. REFERENCES
 #
 #

--- a/pickle_schema.py
+++ b/pickle_schema.py
@@ -68,7 +68,8 @@ def fetch_rows_as_list_of_dictionaries(cursor, select):
 
 def pickle_schema(schema_version, db_name):
     default_file = os.path.expanduser('~/.my.cnf')
-    db = MySQLdb.connect(database=db_name, read_default_file=default_file)
+    db = MySQLdb.connect(database=db_name,
+            read_default_file=default_file, read_default_group='pickle_schema')
     cursor = db.cursor()
     tables = [x[0] for x in select_rows(cursor, 'show tables')]
     schema = {}

--- a/pickle_schema.py
+++ b/pickle_schema.py
@@ -18,6 +18,13 @@
 import MySQLdb
 import pickle
 
+class BzSchemaPickleException(Exception):
+    def __init__(self, message):
+        super().__init__(message)
+        self.message = message
+    def __str__(self):
+        return self.message
+
 def fetchall(cursor):
     rows = cursor.fetchall()
     # for some reason, if no rows are returned sometimes one gets () here.
@@ -28,11 +35,11 @@ def fetchall(cursor):
 def select_rows(cursor, select):
     rows = cursor.execute(select)
     if cursor.description == None :
-        raise error("Trying to fetch rows from non-select '%s'"
+        raise BzSchemaPickleException("Trying to fetch rows from non-select '%s'"
                       % select)
     values = fetchall(cursor)
     if values == None :
-        raise error("Select '%s' returned unfetchable rows."
+        raise BzSchemaPickleException("Select '%s' returned unfetchable rows."
                       % select)
     return values
 
@@ -49,7 +56,7 @@ def fetch_rows_as_list_of_dictionaries(cursor, select):
     for value in values:
         result={}
         if len(keys) != len(value) :
-            raise error("Select '%s' returns %d keys but %d columns."
+            raise BzSchemaPickleException("Select '%s' returns %d keys but %d columns."
                           % (select, len(keys), len(value)))
         for j in range(len(keys)):
             result[keys[j]] = value[j]

--- a/updating.rst
+++ b/updating.rst
@@ -24,7 +24,7 @@ For any given release of Bugzilla, the process goes something like this:
   your database host and credentials from the ``[pickle_schema]`` section of
   ``.my.cnf`` in your home directory. For example
 
-.. code-block:: inifile
+  .. code-block:: inifile
 
    [pickle_schema]
    host=localhost

--- a/updating.rst
+++ b/updating.rst
@@ -21,8 +21,13 @@ For any given release of Bugzilla, the process goes something like this:
 
   For this to work you will have to have MySQLdb (the Python MySQL interface
   library).  You can install it with ``pip install mysqlclient``.  It will use
-  your database host and credentials from the ``[client]`` section of
-  ``.my.cnf`` in your home directory.
+  your database host and credentials from the ``[pickle_schema]`` section of
+  ``.my.cnf`` in your home directory. For example::
+
+  [pickle_schema]
+  host=localhost
+  user=bugs
+  password=mypassword
 
   It will create a new pickle file in the pickles/ directory.  You should add
   that file to Git.  Note that you don't need access to MySQL on the web

--- a/updating.rst
+++ b/updating.rst
@@ -13,19 +13,20 @@ For any given release of Bugzilla, the process goes something like this:
   Search for 3.0.9 in schema_remarks.py to see the spots to update.
 
 - If there are schema changes, or if you aren't sure, download the
-  full Bugzilla release, do a vanilla install on your MySQL, start up
-  Python, and run ``pickle_schema.pickle_schema(version, db_name)``.  For
+  full Bugzilla release, do a vanilla install on your MySQL, then run
+  ``./pickle_schema.py version db_name``.  For
   instance::
 
-  >>> import pickle_schema
-  >>> pickle_schema.pickle_schema('3.8.12','bugs')
-  >>>
+  > ./pickle_schema.py 3.8.12 bugs
 
   For this to work you will have to have MySQLdb (the Python MySQL interface
-  library).  You can install it with ``pip install mysqlclient``.  It will
-  create a new pickle file in the pickles/ directory.  You should add that file
-  to Git.  Note that you don't need access to MySQL on the web server.  You
-  only need the pickle files.
+  library).  You can install it with ``pip install mysqlclient``.  It will use
+  your database host and credentials from the ``[client]`` section of
+  ``.my.cnf`` in your home directory.
+
+  It will create a new pickle file in the pickles/ directory.  You should add
+  that file to Git.  Note that you don't need access to MySQL on the web
+  server.  You only need the pickle files.
 
 - Then add the release to the main release tables in schema_remarks.py
   (``version_order``, ``version_schema_map``, ``version_remark``, and

--- a/updating.rst
+++ b/updating.rst
@@ -24,7 +24,7 @@ For any given release of Bugzilla, the process goes something like this:
   your database host and credentials from the ``[pickle_schema]`` section of
   ``.my.cnf`` in your home directory. For example
 
-  .. code-block:: inifile
+  .. code-block:: ini
 
    [pickle_schema]
    host=localhost

--- a/updating.rst
+++ b/updating.rst
@@ -26,10 +26,10 @@ For any given release of Bugzilla, the process goes something like this:
 
 .. code-block:: inifile
 
-  [pickle_schema]
-  host=localhost
-  user=bugs
-  password=mypassword
+   [pickle_schema]
+   host=localhost
+   user=bugs
+   password=mypassword
 
   It will create a new pickle file in the pickles/ directory.  You should add
   that file to Git.  Note that you don't need access to MySQL on the web

--- a/updating.rst
+++ b/updating.rst
@@ -22,8 +22,9 @@ For any given release of Bugzilla, the process goes something like this:
   For this to work you will have to have MySQLdb (the Python MySQL interface
   library).  You can install it with ``pip install mysqlclient``.  It will use
   your database host and credentials from the ``[pickle_schema]`` section of
-  ``.my.cnf`` in your home directory. For example::
+  ``.my.cnf`` in your home directory. For example
 
+.. code-block:: inifile
   [pickle_schema]
   host=localhost
   user=bugs
@@ -40,9 +41,7 @@ For any given release of Bugzilla, the process goes something like this:
 
 - Then get a plain schema doc, either through the CGI or by hand::
 
-  >>> import make_schema_doc
-  >>> make_schema_doc.write_file('3.0.0','3.8.12','foo.html')
-  >>>
+  > ./make_schema_doc.py 3.0.0 3.8.12 foo.html
 
   This will generate a list of errors, complaining about schema
   changes (new or removed tables, columns or indexes) which aren't

--- a/updating.rst
+++ b/updating.rst
@@ -3,7 +3,12 @@ How to Update
 
 For any given release of Bugzilla, the process goes something like this:
 
-- Check the nodocs diffs to see whether there are any schema changes.
+- As of Bugzilla version 2.20, you can diff Bugzilla/DB/Schema.pm from one
+  version to the next to see if there were schema changes.::
+
+  > git diff release-2.20..release-2.22 -- Bugzilla/DB/Schema.pm
+
+  If that gives you no output, there were no changes.
 
 - If you are *sure* there are none, just add the release to a few
   places in schema_remarks.py (``version_order``, ``version_schema_map``,

--- a/updating.rst
+++ b/updating.rst
@@ -25,6 +25,7 @@ For any given release of Bugzilla, the process goes something like this:
   ``.my.cnf`` in your home directory. For example
 
 .. code-block:: inifile
+
   [pickle_schema]
   host=localhost
   user=bugs

--- a/updating.rst
+++ b/updating.rst
@@ -16,15 +16,16 @@ For any given release of Bugzilla, the process goes something like this:
   full Bugzilla release, do a vanilla install on your MySQL, start up
   Python, and run ``pickle_schema.pickle_schema(version, db_name)``.  For
   instance::
+
   >>> import pickle_schema
   >>> pickle_schema.pickle_schema('3.8.12','bugs')
   >>>
 
-  For this to work you will have to have MySQLdb (the Python MySQL
-  interface library).  It will create a new pickle file in the
-  pickles/ directory.  You should add that file to Git.  Note that you
-  don't need access to MySQL on the web server.  You only need the
-  pickle files.
+  For this to work you will have to have MySQLdb (the Python MySQL interface
+  library).  You can install it with ``pip install mysqlclient``.  It will
+  create a new pickle file in the pickles/ directory.  You should add that file
+  to Git.  Note that you don't need access to MySQL on the web server.  You
+  only need the pickle files.
 
 - Then add the release to the main release tables in schema_remarks.py
   (``version_order``, ``version_schema_map``, ``version_remark``, and
@@ -32,6 +33,7 @@ For any given release of Bugzilla, the process goes something like this:
   section of ``afterword``.
 
 - Then get a plain schema doc, either through the CGI or by hand::
+
   >>> import make_schema_doc
   >>> make_schema_doc.write_file('3.0.0','3.8.12','foo.html')
   >>>


### PR DESCRIPTION
I'm attempting to resurrect this project because it was hella useful. :-)

And I needed it to run on a modern web server.

So here's a PR to make it run under Python 3.

A couple minor changes included here that are unrelated to the Python 3 conversion:
* All absolute links (/tool/bugzilla-schema/*) were made relative to make it easier to self-host at a different URL
* The links in the header/footer for Ravenbrook and the Ravenbrook tools page were removed. The shoutout to Ravenbrook for writing it is still in the main text on the front page.
* Both `make_schema_docs.py` and `pickle_schema.py` can now be run from the command line instead of having to use the python interpreter shell.
* `make_schema_docs.py --validate` will now check if version numbers got entered all three places they're supposed to.